### PR TITLE
Fix breaking typo: "RME" > "REM"

### DIFF
--- a/hr_quick_start.sql
+++ b/hr_quick_start.sql
@@ -6,12 +6,12 @@ REM by guiding the novice as best as possible to ensure a sucessfull installatio
 REM of the schema.  Things it will endeavour to do:
 REM
 REM  - not let you install into a root container by mistake
-REM  - make sure are connected correctly
+REM  - make sure you are connected correctly
 REM  - if you are connected as HR, we'll try reload the schema objects and keep the user
 REM  - if you are connected not as HR, we'll try drop/recreate the HR schema
 REM  - we check for required privs in the HR schema
 REM  - we check for required privs for an admin to build the HR schema from scratch
-REM  - we check to appropriate tablespace quotas
+REM  - we check for appropriate tablespace quotas
 REM  - we check for default tablespaces
 REM  - we check for existing sessions as HR which would block a drop
 REM  - we check for OS file writability for spool files
@@ -19,8 +19,8 @@ REM
 REM In all cases, we try to provide guidance on remedial action to follow if 
 REM the installation fails or cannot proceed.
 REM
-RME Like anything, you could come up with a bizarre set of circumstances in which
-REM this can be broken, but it should work for most. If do you break it, please
+REM Like anything, you could come up with a bizarre set of circumstances in which
+REM this can be broken, but it should work for most. If you do you break it, please
 REM get in touch so I can make it even more carefree for beginners.
 REM 
 REM


### PR DESCRIPTION
Changed "RME" to "REM" to fix script.
Also, edited the docstring a little.