### PR TITLE
HR password now complies with BaseDB verifier

### DIFF
--- a/hr_quick_start.sql
+++ b/hr_quick_start.sql
@@ -434,7 +434,7 @@ from   database_properties
 where  PROPERTY_NAME = 'DEFAULT_TEMP_TABLESPACE';
 
 col rndstr new_value pass
-select dbms_random.string('A',10)||'$'||trunc(dbms_random.value(100,999)) rndstr from dual;
+select dbms_random.string('A',10)||'$$'||trunc(dbms_random.value(100,999)) rndstr from dual;
 set termout on
 
 set termout off


### PR DESCRIPTION
BaseDB password verifier was failing with:
```
CREATE USER hr IDENTIFIED BY JflyqXQUOh$971
*
ERROR at line 1:
ORA-28003: password verification for the specified password failed
ORA-20000: password must contain 2 or more special characters
```
Added a second dollar sign to make it compliant with the rule.